### PR TITLE
Updated streams quickstart notebook to use DynamicMap.event

### DIFF
--- a/notebooks/quickstart/streams.ipynb
+++ b/notebooks/quickstart/streams.ipynb
@@ -286,6 +286,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The ``update`` method is one way to update stream parameters although the ``event`` method on ``DynamicMap`` is the recommended approach as we will now show."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Streams and DynamicMap"
    ]
   },
@@ -304,7 +311,8 @@
    },
    "outputs": [],
    "source": [
-    "hv.DynamicMap(sine_image, kdims=[], streams=[sine_params])"
+    "dmap = hv.DynamicMap(sine_image, kdims=[], streams=[sine_params])\n",
+    "dmap"
    ]
   },
   {
@@ -331,6 +339,35 @@
    "source": [
     "We did not need to change the ``sine_image`` callback - whereas the arguments were passed in by position when ``kdims`` were used (see the sliders example above) they are now passed by name via keyword arguments.\n",
     "\n",
+    "As a ``DynamicMap`` can have access to the parameters to multiple streams, having to hold handles to the stream objects themselves can be awkward. The recommended way to update *any* of the available stream parameters is to call the ``event`` method on the ``DynamicMap`` itself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dmap.event(freq=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This approach only requires a handle on the DynamicMap (``dmap``), allowing you to declare the streams at the same time as you declare the rest of the ``DynamicMap``. In other words, we could have declared our dynamicmap in a single line using:\n",
+    "\n",
+    "```\n",
+    "dmap = hv.DynamicMap(sine_image, kdims=[], streams=[SineParameters()])\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now we will update the frequency of the plot above using a simple loop:"
    ]
   },
@@ -343,7 +380,7 @@
    "outputs": [],
    "source": [
     "for freq in np.linspace(0.1, 2):\n",
-    "    sine_params.update(freq=freq)"
+    "    dmap.event(freq=freq)"
    ]
   },
   {
@@ -361,7 +398,7 @@
    },
    "outputs": [],
    "source": [
-    "sine_params.update(freq=2, phase=np.pi/2)"
+    "dmap.event(freq=2, phase=np.pi/2)"
    ]
   },
   {
@@ -379,7 +416,7 @@
    },
    "outputs": [],
    "source": [
-    "sine_params.update(freq=2, phase=0)"
+    "dmap.event(freq=2, phase=0)"
    ]
   },
   {
@@ -400,7 +437,7 @@
     "phase = 0\n",
     "for i in range(200):\n",
     "    phase += 0.3\n",
-    "    sine_params.update(phase=phase)"
+    "    dmap.event(phase=phase)"
    ]
   },
   {
@@ -419,14 +456,15 @@
    "outputs": [],
    "source": [
     "%%opts Image (cmap='viridis')\n",
-    "hv.DynamicMap(sine_image, kdims=[], streams=[sine_params]) + sine_image(0,1)"
+    "layout = hv.DynamicMap(sine_image, kdims=[], streams=[SineParameters(freq=1)]) + sine_image(0,1)\n",
+    "layout"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that when you update the phase in a loop, both the visualization above and the one before it update as both of the ``DynamicMap`` object involves use the same stream:"
+    "Now we can update the phase in a loop by accessing the ``DynamicMap`` in the ``Layout`` and calling the ``event`` method:"
    ]
   },
   {
@@ -440,14 +478,16 @@
     "phase = 0\n",
     "for i in range(50):\n",
     "    phase += 0.3\n",
-    "    sine_params.update(phase=phase)"
+    "    layout.DynamicMap.I.event(phase=phase)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You will notice that the visualizations update much slower - not only is the layout a more complex plot but matplotlib is now re-rendering two sets of plots at once and the results have to be communicated to the browser. For many elements, you will get get better performance using the [Bokeh backend](http://holoviews.org/Tutorials/Bokeh_Elements.html) and for more information about the options system, see the [Options tutorial](http://holoviews.org/Tutorials/Options.html)."
+    "Note that had we shared the stream instance (i.e used ``sine_params`` above) we could have used this loop to update two visualizations at once.\n",
+    "\n",
+    "You will notice that the visualizations updates slower as the layout a more complex plot. For many elements, you will get get better performance using the [Bokeh backend](http://holoviews.org/Tutorials/Bokeh_Elements.html) and for more information about the options system, see the [Options tutorial](http://holoviews.org/Tutorials/Options.html)."
    ]
   }
  ],


### PR DESCRIPTION
Now ``DynamicMap`` has an ``event`` method to update stream parameter values, I would recommend this approach over using ``update`` on individual stream objects. This PR updates the quickstart to describe this method and encourage its usage.