### PR TITLE
Added bokeh_streams notebook quickstart guide

### DIFF
--- a/notebooks/quickstart/bokeh_streams.ipynb
+++ b/notebooks/quickstart/bokeh_streams.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
+    "<dl class=\"dl-horizontal\">\n",
+    "  <dt>Description</dt> <dd> Bokeh streams quickstart guide</dd>\n",
+    "  <dt>Author</dt> <dd>Jean-Luc Stevens</dd>\n",
+    "  <dt>HoloViews</dt> <dd>>1.6.2</dd>\n",
+    "  <dt>Python</dt> <dd>2.7/3.3+</dd>\n",
+    "</dl>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This quickstart is designed to introduce the basics of the streams system interacts with the [Bokeh](http://bokeh.pydata.org/) backend in HoloViews 1.7+. This quickstart guide focuses on stream functionality specific to the Bokeh backend and builds on the introductory [streams quickstart](quickstart/streams.ipynb) notebook. This notebook uses core HoloViews together with the bokeh backend and shows how you can build visualizations that you can directly interact with. To install bokeh with conda, use:\n",
+    "\n",
+    "```bash\n",
+    "conda install bokeh\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "import numpy as np\n",
+    "from holoviews import streams\n",
+    "hv.notebook_extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Direct interaction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unlike matplotlib, the [Bokeh](http://bokeh.pydata.org/) plotting library is designed to support interactive visualizations in the browser. This makes it possible for HoloViews to build Bokeh plots that communicate back to Python from the browser via the stream system allowing direct interaction with your visualizations.\n",
+    "\n",
+    "As soon as the bokeh backend is enabled, direct interaction is also enabled. This means that the no new concepts need to be introduced relative to the [streams quickstart](quickstart/streams.ipynb). For instance, here is a simple example using the ``PositionXY`` stream which is already Bokeh enabled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def crosshairs(x,y):\n",
+    "    print \"x: %s y:%s\" %(x,y)\n",
+    "    return hv.HLine(y) * hv.VLine(x) * hv.Ellipse(0,0, 1)\n",
+    "\n",
+    "dmap = hv.DynamicMap(crosshairs, kdims=[], streams=[streams.PositionXY(x=0,y=0)])\n",
+    "dmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now when you hover over the plot, the crosshair will follow your mouse!\n",
+    "\n",
+    "Note that on initialization, we see the initial print message showing that the stream is initialized with ``x=0, y=0``. As before, you can use the ``event`` method on the ``DynamicMap`` which also shows the print message and updates the visualization above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dmap.event(x=0.2,y=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may be wondering what happens to the print messages when you use the mouse to move the crosshair: the callback is being executed but no print messages are appearing in the notebook. This is because when interacting with the stream in the browser, the callback output is only used to update the plot and there is no other mechanism to update the notebook document. \n",
+    "\n",
+    "These print messages do not vanish entirely: if you go to your browser console you will see that the print output is converted into logging messages in JavaScript. This can help with debugging interaction but it is often simpler to supply explicit values using the ``event`` method which does allow print output to appear in the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dmap.event(x=0.3, y=0.3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/quickstart/bokeh_streams.ipynb
+++ b/notebooks/quickstart/bokeh_streams.ipynb
@@ -110,6 +110,90 @@
    "source": [
     "dmap.event(x=0.3, y=0.3)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bokeh tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some of the streams are tied to [Bokeh tools](http://bokeh.pydata.org/en/latest/docs/user_guide/tools.html) which means that the events that drive the stream are only generated when the appropriate Bokeh tool is active.\n",
+    "\n",
+    "For instance, in the following example, you need to select the 'Box Select' tool from the toolbar on the right before you can draw new ``Bounds`` objects at the position you want:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dmap = hv.DynamicMap(lambda bounds: hv.Bounds(bounds, extents=(-5, -5, 5, 5)),\n",
+    "              kdims=[], streams=[streams.Bounds(bounds=(-1,-1,1,1))])\n",
+    "dmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before you can use the ``event`` method to update the stream parameter value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "dmap.event(bounds=(-1,-3,1,3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting the source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The source of the events used to update the stream correspond to the portion of the visualization that corresponds to the ``DynamicMap`` itself. However, this does not have to be the case and you can receive events from any part of the visualization, including from portions that correspond to simple elements.\n",
+    "\n",
+    "In the following example, an ``Image`` called ``img`` is declared and the position of the cursor over this image is what sets the values in the ``PositionXY`` stream, even though it is used only by the ``DynamicMap`` on the right side of the ``Layout``. Note that ``img`` is set as the ``source`` of the ``PositionXY`` stream:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = hv.Image(np.random.rand(10,10))\n",
+    "extents = (-.5, -.5, .5, .5)\n",
+    "img + hv.DynamicMap(lambda x, y: hv.HLine(y, extents=extents) * hv.VLine(x, extents=extents),\n",
+    "              kdims=[], streams=[streams.PositionXY(source=img)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now when you hover over the image on the left, the position of the crosshair on the right is updated."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This notebook is designed to quickly introduce interactive streams using the bokeh backend. So far I've given one example and explained why ``event`` should be used and mentioned that print output goes to the web console.

This PR isn't complete but I wanted to get this notebook started so we have something useful by the time we release 1.7.