### PR TITLE
Game of Life simulator demonstrating dimensioned streams

### DIFF
--- a/notebooks/quickstart/game_of_life_simulator.ipynb
+++ b/notebooks/quickstart/game_of_life_simulator.ipynb
@@ -371,7 +371,7 @@
     "    \n",
     "    def history_until(self, time):\n",
     "        self.run_until(time)\n",
-    "        return hv.Image(np.array(self._history.data))\n",
+    "        return hv.Image(self._history.data)\n",
     "    \n",
     "    def points_until(self, time):\n",
     "        board = self.run_until(time)\n",

--- a/notebooks/quickstart/game_of_life_simulator.ipynb
+++ b/notebooks/quickstart/game_of_life_simulator.ipynb
@@ -43,6 +43,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "First let's set some general style options:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%opts Image (cmap='Blues_r') Overlay [title_format='' xaxis=None yaxis=None]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Conway's Game of Life"
    ]
   },
@@ -375,7 +393,8 @@
     "    \n",
     "    def points_until(self, time):\n",
     "        board = self.run_until(time)\n",
-    "        lin = np.linspace(-0.5, 0.5, board.data.shape[0])\n",
+    "        delta = 1.0 / board.data.shape[0]\n",
+    "        lin = np.linspace(-0.5+delta/2, 0.5-delta/2, board.data.shape[0])\n",
     "        x,y = np.meshgrid(lin, lin)\n",
     "        return hv.Points([(x,-y) for (x,y,s) in zip(x.flatten(),y.flatten(), board.data.flatten()) if s])"
    ]
@@ -457,6 +476,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this final example we will want to view a bigger board and set a few ``Point`` style options:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -464,14 +490,15 @@
    },
    "outputs": [],
    "source": [
-    "%opts Points (color='g' s=10)"
+    "%output size=200\n",
+    "%opts Points (color='w' s=50 marker='s' edgecolor='k' lw=1)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life state as points, overlaid on top of the history starting with a larger, randomized initial state:"
+    "As a demonstration of how dimensioned streams allow you to run open-ended simulations, here is a visualization of the Game of Life state as points, overlaid on top of the history starting with a larger, randomized initial state:"
    ]
   },
   {
@@ -482,7 +509,7 @@
    },
    "outputs": [],
    "source": [
-    "pattern = (np.random.rand(100,100) < 0.5).astype(int)\n",
+    "pattern = (np.random.rand(50,50) < 0.5).astype(int)\n",
     "GoL = GameOfLife(pattern=pattern, padding=0)\n",
     "time = SimulationTime()\n",
     "sim4_history = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time], cache_size=20)\n",

--- a/notebooks/quickstart/game_of_life_simulator.ipynb
+++ b/notebooks/quickstart/game_of_life_simulator.ipynb
@@ -371,14 +371,20 @@
     "    \n",
     "    def history_until(self, time):\n",
     "        self.run_until(time)\n",
-    "        return hv.Image(self._history.data)"
+    "        return hv.Image(np.array(self._history.data))\n",
+    "    \n",
+    "    def points_until(self, time):\n",
+    "        board = self.run_until(time)\n",
+    "        lin = np.linspace(-0.5, 0.5, board.data.shape[0])\n",
+    "        x,y = np.meshgrid(lin, lin)\n",
+    "        return hv.Points([(x,-y) for (x,y,s) in zip(x.flatten(),y.flatten(), board.data.flatten()) if s])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The 'history' is a view of the world over time, where cells are marked with the most recent time when an 'alive' cell was present. To illustrate, here is the world state after ten steps next to this view of the history:"
+    "The 'history' is a view of the world over time, where cells are marked with the most recent time when an 'alive' cell was present. The ``points_until`` method simply generates a ``Points`` version of the Game of Life board. To illustrate, here is the world state after ten steps next to this view of the history:"
    ]
   },
   {
@@ -451,10 +457,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%opts Points (color='g' s=10)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life state next to its history starting with a larger, randomized initial state:"
+    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life state as points, overlaid on top of the history starting with a larger, randomized initial state:"
    ]
   },
   {
@@ -465,13 +482,12 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Image {+axiswise}\n",
     "pattern = (np.random.rand(100,100) < 0.5).astype(int)\n",
     "GoL = GameOfLife(pattern=pattern, padding=0)\n",
     "time = SimulationTime()\n",
     "sim4_history = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time], cache_size=20)\n",
-    "sim4 = hv.DynamicMap(GoL.run_until, kdims=['time'], streams=[time], cache_size=20)\n",
-    "sim4 + sim4_history"
+    "sim4 = hv.DynamicMap(GoL.points_until, kdims=['time'], streams=[time], cache_size=20)\n",
+    "sim4_history * sim4"
    ]
   },
   {
@@ -492,7 +508,7 @@
     "for t in range(101):\n",
     "    sim4.event(time=t)\n",
     "    \n",
-    "hv.HoloMap(sim4)"
+    "hv.HoloMap(sim4_history) * hv.HoloMap(sim4)"
    ]
   },
   {

--- a/notebooks/quickstart/game_of_life_simulator.ipynb
+++ b/notebooks/quickstart/game_of_life_simulator.ipynb
@@ -409,6 +409,7 @@
    },
    "outputs": [],
    "source": [
+    "%%opts Image {+axiswise}\n",
     "GoL = GameOfLife()\n",
     "time = SimulationTime()\n",
     "sim3 = hv.DynamicMap(GoL.run_until, kdims=['time'], streams=[time])\n",
@@ -453,7 +454,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life history starting with a larger, randomized initial state:"
+    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life state next to its history starting with a larger, randomized initial state:"
    ]
   },
   {
@@ -464,19 +465,20 @@
    },
    "outputs": [],
    "source": [
-    "%%output size=200\n",
-    "pattern = (np.random.rand(100,100) < 0.5)\n",
+    "%%opts Image {+axiswise}\n",
+    "pattern = (np.random.rand(100,100) < 0.5).astype(int)\n",
     "GoL = GameOfLife(pattern=pattern, padding=0)\n",
     "time = SimulationTime()\n",
-    "sim4 = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time], cache_size=20)\n",
-    "sim4"
+    "sim4_history = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time], cache_size=20)\n",
+    "sim4 = hv.DynamicMap(GoL.run_until, kdims=['time'], streams=[time], cache_size=20)\n",
+    "sim4 + sim4_history"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now advance 200 frames while keeping track of the most recent twenty frames in a ``HoloMap``:"
+    "We can now advance 100 steps while keeping track of the most recent twenty frames in a ``HoloMap``:"
    ]
   },
   {
@@ -487,7 +489,7 @@
    },
    "outputs": [],
    "source": [
-    "for t in range(201):\n",
+    "for t in range(101):\n",
     "    sim4.event(time=t)\n",
     "    \n",
     "hv.HoloMap(sim4)"
@@ -497,7 +499,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then then we can continue to advance the simulation another 200 frames in the knowledge that we always have the last twenty frames available if we wish to inspect them:"
+    "Then then we can continue to advance the simulation another 100 steps in the knowledge that we always have the last twenty frames available if we wish to inspect them:"
    ]
   },
   {
@@ -508,7 +510,7 @@
    },
    "outputs": [],
    "source": [
-    "for t in range(201, 401):\n",
+    "for t in range(101, 201):\n",
     "    sim4.event(time=t)"
    ]
   }

--- a/notebooks/quickstart/game_of_life_simulator.ipynb
+++ b/notebooks/quickstart/game_of_life_simulator.ipynb
@@ -1,0 +1,537 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
+    "<dl class=\"dl-horizontal\">\n",
+    "  <dt>Description</dt> <dd> Game of Life Simulator quickstart guide</dd>\n",
+    "  <dt>Author</dt> <dd>Jean-Luc Stevens</dd>\n",
+    "  <dt>HoloViews</dt> <dd>>1.6.2</dd>\n",
+    "  <dt>Python</dt> <dd>2.7/3.3+</dd>\n",
+    "</dl>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This quickstart is designed to demonstrate how an open-ended simulation can be integrated with HoloViews, starting from HoloViews 1.7. Using [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) as an example of a system to simulate, this quickstart guide shows how the streams system supports dimensioned streams to keep track of simulation time. This notebook uses core HoloViews together with the matplotlib backend and also requires [scipy](https://www.scipy.org/) which can be installed using conda with:\n",
+    "\n",
+    "```bash\n",
+    "conda install scipy\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "from holoviews import streams\n",
+    "import numpy as np\n",
+    "hv.notebook_extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conway's Game of Life"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) is a famous example of a 2D cellular automata. The simulations runs on a grid, consisting of cells that can be in one of two states: 'alive' (on) or 'dead' (off). The simulation is updated in discrete steps and the next state of a cell depends on the state of its eight neighbors:\n",
+    "\n",
+    "* Any live cell with fewer than two live neighbours dies ('under-population')\n",
+    "* Any live cell with two or three live neighbours survives and lives on to the next generation.\n",
+    "* Any live cell with more than three live neighbours dies ('over-population').\n",
+    "* Any dead cell with exactly three live neighbours becomes a live cell ('reproduction').\n",
+    "\n",
+    "Using the ``convolve2d`` function from ``scipy``, we can use a very simple convolution kernel to cover the eight neighbors and effectively count the surrounding live cells. The details are not too important, what matters is the core of the Game of Life can be written as follows to compute the next state of boolean array ``X``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.signal import convolve2d\n",
+    "\n",
+    "def single_step(X):\n",
+    "    \"Compute the next step in the Game of Life using a 2D convolution\"\n",
+    "    nbrs_count = convolve2d(X, np.ones((3, 3)), mode='same', boundary='wrap') - X\n",
+    "    return (nbrs_count == 3) | (X & (nbrs_count == 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To test it, we will declare a board containing the famous [glider pattern](https://en.wikipedia.org/wiki/Glider_(Conway%27s_Life)) to check this function correctly advances by one simulation step:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "glider = [[1, 0, 0], [0, 1, 1], [1, 1, 0]]\n",
+    "board = hv.Image(np.pad(np.array(glider, dtype=int), 5, 'constant'))\n",
+    "board + hv.Image(single_step(board.data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now this seems to work, lets build the simplest version of our simulator by declaring the following class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class GameOfLifeSimple(object):\n",
+    "    \"\"\"\n",
+    "    Simple simulator of Conway's Game of Life that starts with a \n",
+    "    given starting pattern (a simple glider by default) and some\n",
+    "    specified level of padding around it.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    def __init__(self, pattern=np.array(glider, dtype=int), padding=5):\n",
+    "        self.time = 0\n",
+    "        self.board = hv.Image(np.pad(pattern, padding, 'constant'))\n",
+    "        \n",
+    "    def step(self):\n",
+    "        \"Advance the state by one step, returning a new Image \"\n",
+    "        data = single_step(self.board.data)\n",
+    "        self.board.data = data\n",
+    "        self.time += 1\n",
+    "        return hv.Image(data)\n",
+    "    \n",
+    "    def run_until(self, time):\n",
+    "        \"Advance the simulation to the specified time\"\n",
+    "        times = range(self.time, time)\n",
+    "        for t in times:\n",
+    "            state = self.step()\n",
+    "        return state if times else hv.Image(self.board.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using this class, we can use the ``run_until`` method to move forward nine steps at once in simulation time, making it clear that the glider is moving diagonally downwards to the right:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "GoL = GameOfLifeSimple()\n",
+    "board  + GoL.run_until(9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using a ``HoloMap`` is one way to interact with the simulation although we are limited in how many steps can be sampled before we use up too much memory. The advantage of HoloMaps is that they can be used after exporting the notebook to HTML. Let's make a HoloMap showing our glider over 10 steps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "GoL = GameOfLifeSimple()\n",
+    "hv.HoloMap({t:GoL.run_until(t) for t in range(10)}, kdims=[hv.Dimension('Time', type=int)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using DynamicMap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Game of Life is a simulation that is unbounded and can be run forever, even if the state of the world eventually reaches a steady state. For this reason, both ``HoloMaps`` and bounded ``DynamicMaps`` are not ideal as we want the ability to leave the simulation running for as long as we like.\n",
+    "\n",
+    "In HoloViews 1.7, you can use the streams system together with ``DynamicMap`` to define and open-ended simulation. In the following cell, a custom ``Stream `` is defined and used to build an open-ended simulation in the for of a ``DynamicMap`` called ``sim1``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "\n",
+    "class SimulationTime(streams.Stream):\n",
+    "    \n",
+    "    time = param.Integer(default=0, bounds=(0,None))\n",
+    "\n",
+    "GoL = GameOfLifeSimple()\n",
+    "sim1 = hv.DynamicMap(GoL.run_until, kdims=[], streams=[SimulationTime()])\n",
+    "sim1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more information about streams, see the [streams quickstart ](streams.ipynb) guide. We can now advance ``sim1`` using the ``event`` method to make our glider wrap once around its tiny world:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for t in range(1, 53):\n",
+    "    sim1.event(time=t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This approach of declaring a ``DynamicMap`` without any ``kdims`` and using streams is great for visualizing live data without holding onto any state. The problem with this is that we have no history and cannot revisit previous state as the ``DynamicMap`` has no elements cached:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sim1.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This also means we cannot make a ``HoloMap`` out of such ``DynamicMaps`` as they have no key dimensions. You can declare stream parameters as key dimensions, using *dimensioned streams*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dimensioned streams"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use dimensioned streams, simply declare the stream parameter (in this instance, this is the parameter ``time`` of ``SimulationTime``) in the list of ``kdims``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "GoL = GameOfLifeSimple()\n",
+    "sim2 = hv.DynamicMap(GoL.run_until, kdims=['time'], streams=[SimulationTime()], cache_size=10)\n",
+    "sim2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this time, when we update the time stream, the relevant time is shown in the title because it has now declared as a ``kdim``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "for t in range(53):\n",
+    "    sim2.event(time=t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When declaring the ``DynamicMap``, a value of ``cache_size=10`` was specified which means we now have the past ten values of the ``'time'`` dimension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sim2.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we now have keys for our cache, we can now turn the last ten steps of the simulation into a ``HoloMap`` that can be exported with the notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "hv.HoloMap(sim2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rich Simulations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current simulation example is quite simple as there is only one type of state to worry about (the state of the cells in the world). Now we will extend this simple simulator to have more than one type of state we can visualize at a given time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class GameOfLife(GameOfLifeSimple):\n",
+    "    \n",
+    "    def __init__(self, **kwargs):\n",
+    "        super(GameOfLife, self).__init__(**kwargs)\n",
+    "        self._history = hv.Image(np.ones(self.board.data.shape) * self.time)\n",
+    "        \n",
+    "    def step(self):\n",
+    "        state = super(GameOfLife, self).step()\n",
+    "        self._history.data = np.where(state.data==1, state.data*self.time, self._history.data)\n",
+    "        return state\n",
+    "    \n",
+    "    def history_until(self, time):\n",
+    "        self.run_until(time)\n",
+    "        return hv.Image(self._history.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 'history' is a view of the world over time, where cells are marked with the most recent time when an 'alive' cell was present. To illustrate, here is the world state after ten steps next to this view of the history:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image {+axiswise}\n",
+    "GoL = GameOfLife()\n",
+    "GoL.run_until(10) + GoL.history_until(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now using the same ``SimulationTime`` stream class and a single instance ``time``, we can advance the state of our simulator while visualizing multiple types of state at once, using the usual HoloViews ``+`` and ``*`` operators. For instance, after defining two ``DynamicMaps`` called ``sim3`` and ``history``, we can do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "GoL = GameOfLife()\n",
+    "time = SimulationTime()\n",
+    "sim3 = hv.DynamicMap(GoL.run_until, kdims=['time'], streams=[time])\n",
+    "history = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time])\n",
+    "sim3 + history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which we can advance as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for t in range(53):\n",
+    "    sim3.event(time=t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we can pick either of our ``DynamicMaps`` to advance time on as both are sharing the same ``time`` stream parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A final example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To show how using dimensioned streams allows you to run open-ended simulations, here is a visualization of the Game of Life history starting with a larger, randomized initial state:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%output size=200\n",
+    "pattern = (np.random.rand(100,100) < 0.5)\n",
+    "GoL = GameOfLife(pattern=pattern, padding=0)\n",
+    "time = SimulationTime()\n",
+    "sim4 = hv.DynamicMap(GoL.history_until, kdims=['time'], streams=[time], cache_size=20)\n",
+    "sim4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now advance 200 frames while keeping track of the most recent twenty frames in a ``HoloMap``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for t in range(201):\n",
+    "    sim4.event(time=t)\n",
+    "    \n",
+    "hv.HoloMap(sim4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then then we can continue to advance the simulation another 200 frames in the knowledge that we always have the last twenty frames available if we wish to inspect them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for t in range(201, 401):\n",
+    "    sim4.event(time=t)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This PR adds a quickstart guide to using dimensioned streams for use with open-ended simulations. It needs a little more work as well as a few fixes in HoloViews:

* With the default cache size of 500, the simulation slows down over time. Using small cache sizes keeps the simulation speed reasonable and steady.
* There is a bug to fix in the validation of stream parameters when using layouts/overlays. Most likely to do with the new Callable API which results in the collection of more (nested) streams.

I think that this notebook also shows that we can deprecate 'counter mode' from ``DynamicMap`` as this new approach seems more useful to me...