### PR TITLE
Quickstart notebook updates for 1.7

### DIFF
--- a/notebooks/quickstart/bokeh_streams.ipynb
+++ b/notebooks/quickstart/bokeh_streams.ipynb
@@ -67,7 +67,7 @@
     "    print \"x: %s y:%s\" %(x,y)\n",
     "    return hv.HLine(y) * hv.VLine(x) * hv.Ellipse(0,0, 1)\n",
     "\n",
-    "dmap = hv.DynamicMap(crosshairs, kdims=[], streams=[streams.PositionXY(x=0,y=0)])\n",
+    "dmap = hv.DynamicMap(crosshairs, kdims=[], streams=[streams.PointerXY(x=0,y=0)])\n",
     "dmap"
    ]
   },
@@ -184,8 +184,7 @@
    "source": [
     "img = hv.Image(np.random.rand(10,10))\n",
     "extents = (-.5, -.5, .5, .5)\n",
-    "img + hv.DynamicMap(lambda x, y: hv.HLine(y, extents=extents) * hv.VLine(x, extents=extents),\n",
-    "              kdims=[], streams=[streams.PositionXY(source=img)])"
+    "hv.DynamicMap(lambda x, y: hv.HLine(y) * hv.VLine(x), kdims=[], streams=[streams.PointerXY()])"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the quickstart notebooks ahead of the 1.7 release. 

The following two notebooks run fine right now: ``dynamic_rendering`` and ``streams``.  

Unfortunately there are some issues with ``game_of_life_simulator`` and ``bokeh_streams``:

In ``game_of_life_simulator`` the dynamic overlay operation at the end of the notebook (``sim4_history * sim4``) doesn't work even though each individual dynamicmap works fine in isolation.

In ``bokeh_streams``, the last cell doesn't work. This seems to be due to the annotations as I can reproduce the issue with a simpler example:

```python
hv.DynamicMap(lambda x, y:  hv.Curve([(x,y), (2,2)]) * hv.VLine(x), 
     kdims=[], streams=[streams.PointerXY()])
```

I'm now going to update the ``streams`` notebook, not because it doesn't work but because I'm sick of looking at sine rings! I'll match the pattern used in the updated DynamicMap tutorial.


